### PR TITLE
chore(circleci): remove trailing spaces in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
     executor: ci-executor
     steps:
       - checkout
-      
       - run:
           name: build dependencies
           command: bundle install
@@ -20,7 +19,6 @@ jobs:
       - run:
           name: notify build is finished
           command: echo "The build is finished!"
-          
   testlinks:
     executor: ci-executor
     steps:


### PR DESCRIPTION
This will fix issues with trailing spaces in circleci config file reported by CodeFactor.